### PR TITLE
Add (almost all) unit tests

### DIFF
--- a/lib/nc_time_axis/__init__.py
+++ b/lib/nc_time_axis/__init__.py
@@ -1,23 +1,10 @@
-# (C) British Crown Copyright 2016, Met Office
-#
-# This file is part of nc-time-axis.
-#
-# nc-time-axis is free software: you can redistribute it and/or modify it under
-# the terms of the GNU Lesser General Public License as published by the
-# Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# nc-time-axis is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with nc-time-axis. If not, see <http://www.gnu.org/licenses/>.
 """
 Support for netcdftime axis in matplotlib.
 
 """
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
 
 from collections import namedtuple
 import datetime
@@ -65,7 +52,7 @@ class NetCDFTimeDateFormatter(mticker.Formatter):
         return dt.strftime(format_string)
 
 
-class NetCDFtimeDateLocator(mticker.Locator):
+class NetCDFTimeDateLocator(mticker.Locator):
     def __init__(self, max_n_ticks, calendar, date_unit, min_n_ticks=3):
         # The date unit must be in the form of days since ...
 
@@ -158,7 +145,7 @@ class NetCDFtimeDateLocator(mticker.Locator):
         return netcdftime.date2num(ticks, self.date_unit, self.calendar)
 
 
-class NetCDFtimeConverter(mdates.DateConverter):
+class NetCDFTimeConverter(mdates.DateConverter):
     standard_unit = 'days since 2000-01-01'
 
     @staticmethod
@@ -171,7 +158,7 @@ class NetCDFtimeConverter(mdates.DateConverter):
         """
         calendar, date_unit = unit
 
-        majloc = NetCDFtimeDateLocator(4, calendar=calendar, date_unit=date_unit)
+        majloc = NetCDFTimeDateLocator(4, calendar=calendar, date_unit=date_unit)
         majfmt = NetCDFTimeDateFormatter(majloc, calendar=calendar, time_units=date_unit)
         datemin = netcdftime.datetime(2000, 1, 1)
         datemax = netcdftime.datetime(2010, 1, 1)
@@ -211,3 +198,8 @@ class NetCDFtimeConverter(mdates.DateConverter):
             raise ValueError('A "calendar" attribute must be attached to '
                              'netcdftime object to understand them properly.')
         return netcdftime.date2num(value, cls.standard_unit, calendar=first_value.calendar)
+
+
+# Automatically register NetCDFTimeConverter with matplotlib.unit's converter dictionary. 
+if netcdftime.datetime not in munits.registry:
+    munits.registry[netcdftime.datetime] = NetCDFTimeConverter()

--- a/lib/nc_time_axis/tests/__init__.py
+++ b/lib/nc_time_axis/tests/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/nc_time_axis/tests/unit/__init__.py
+++ b/lib/nc_time_axis/tests/unit/__init__.py
@@ -1,0 +1,4 @@
+"""Unit tests for the :mod:`nc-time-axis` package."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa

--- a/lib/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/lib/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -1,0 +1,76 @@
+"""Unit tests for the `nc-time-axis.NetCDFTimeConverter` class."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+import unittest
+
+import netcdftime
+import numpy as np
+
+from nc_time_axis import NetCDFTimeConverter
+
+
+class Test_axisinfo(unittest.TestCase):
+    def test_default_limits(self):
+        unit = ('360_day', 'days since 2000-02-25 00:00:00')
+        result = NetCDFTimeConverter().axisinfo(unit, None)
+        np.testing.assert_array_equal(result.default_limits,
+                                      [netcdftime.datetime(2000, 1, 1),
+                                       netcdftime.datetime(2010, 1, 1)])
+
+
+class Test_default_units(unittest.TestCase):
+    def test_360_day_calendar(self):
+        calendar = '360_day'
+        unit = 'days since 2000-01-01'
+        val = [netcdftime.datetime(2014, 8, 12)]
+        val[0].calendar = calendar
+        result = NetCDFTimeConverter().default_units(val, None)
+        self.assertEqual(result, (calendar, unit))
+
+    def test_no_calendar_attribute(self):
+        val = [netcdftime.datetime(2014, 8, 12)]
+        msg = 'Expecting netcdftimes with an extra "calendar" attribute.'
+        with self.assertRaisesRegexp(ValueError, msg):
+            result = NetCDFTimeConverter().default_units(val, None)
+
+
+class Test_convert(unittest.TestCase):
+    def test_numpy_array(self):
+        val = np.array([7])
+        result = NetCDFTimeConverter().convert(val, None, None)
+        np.testing.assert_array_equal(result, val)
+
+    def test_numeric(self):
+        val = 4
+        result = NetCDFTimeConverter().convert(val, None, None)
+        np.testing.assert_array_equal(result, val)
+
+    def test_numeric_iterable(self):
+        val = [12, 18]
+        result = NetCDFTimeConverter().convert(val, None, None)
+        np.testing.assert_array_equal(result, val)
+
+    def test_netcdftime(self):
+        val = netcdftime.datetime(2014, 8, 12)
+        val.calendar = '365_day'
+        result = NetCDFTimeConverter().convert(val, None, None)
+        np.testing.assert_array_equal(result, 5333.)
+
+    def test_netcdftime_np_array(self):
+        val = np.array([netcdftime.datetime(2012, 6, 4)], dtype=np.object)
+        for date in val:
+            date.calendar = '360_day'
+        result = NetCDFTimeConverter().convert(val, None, None)
+        self.assertEqual(result, np.array([4473.]))
+
+    def test_no_calendar_attribute(self):
+        val = netcdftime.datetime(2014, 8, 12)
+        msg = 'A "calendar" attribute must be attached'
+        with self.assertRaisesRegexp(ValueError, msg):
+            result = NetCDFTimeConverter().convert(val, None, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/nc_time_axis/tests/unit/test_NetCDFTimeDateFormatter.py
+++ b/lib/nc_time_axis/tests/unit/test_NetCDFTimeDateFormatter.py
@@ -1,0 +1,30 @@
+"""Unit tests for the `nc-time-axis.NetCDFTimeDateFormatter` class."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+import unittest
+
+import mock
+
+from nc_time_axis import NetCDFTimeDateFormatter
+
+
+class Test_pick_format(unittest.TestCase):
+    def check(self, ndays):
+        locator = mock.MagicMock()
+        formatter = NetCDFTimeDateFormatter(locator, '360_day',
+                                            'days since 2000-01-01 00:00')
+        return formatter.pick_format(ndays)
+
+    def test(self):
+        self.assertEqual(self.check(0.1), '%H:%M:%S')
+        self.assertEqual(self.check(0.6), '%H:%M')
+        self.assertEqual(self.check(5), '%Y-%m-%d %H:%M')
+        self.assertEqual(self.check(40), '%Y-%m-%d')
+        self.assertEqual(self.check(300), '%Y-%m')
+        self.assertEqual(self.check(1000), '%Y')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lib/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
+++ b/lib/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
@@ -1,0 +1,115 @@
+"""Unit tests for the `nc-time-axis.NetCDFTimeDateLocator` class."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+import unittest
+
+import matplotlib.dates as mdates
+import netcdftime
+import numpy as np
+
+from nc_time_axis import NetCDFTimeDateLocator
+
+
+class Test_compute_resolution(unittest.TestCase):
+    def setUp(self):
+        self.date_unit = 'days since 2004-01-01 00:00'
+        self.calendar = '365_day'
+
+    def check(self, max_n_ticks, num1, num2):
+        locator = NetCDFTimeDateLocator(max_n_ticks=max_n_ticks,
+                                        calendar=self.calendar,
+                                        date_unit=self.date_unit)
+        return locator.compute_resolution(
+            num1, num2,
+            netcdftime.num2date(num1, self.date_unit, self.calendar),
+            netcdftime.num2date(num2, self.date_unit, self.calendar))
+
+    def test_one_minute(self):
+        self.assertEqual(self.check(20, 0, 0.0003),
+                         ('SECONDLY', mdates.SECONDS_PER_DAY))
+        self.assertEqual(self.check(10, 0.0003, 0),
+                         ('SECONDLY', mdates.SECONDS_PER_DAY))
+
+    def test_one_hour(self):
+        self.assertEqual(self.check(1, 0, 0.02), ('MINUTELY', 0))
+        self.assertEqual(self.check(0.02*86400, 0, 0.02),
+                         ('SECONDLY', mdates.SECONDS_PER_DAY))
+
+    def test_one_day(self):
+        self.assertEqual(self.check(1, 0, 1), ('HOURLY', 0))
+        self.assertEqual(self.check(24, 0, 1), ('MINUTELY', 0))
+        self.assertEqual(self.check(86400, 0, 1),
+                         ('SECONDLY', mdates.SECONDS_PER_DAY))
+
+    def test_30_days(self):
+        self.assertEqual(self.check(1, 0, 30), ('DAILY', 30))
+        self.assertEqual(self.check(30, 0, 30), ('HOURLY', 1))
+        self.assertEqual(self.check(30*24, 0, 30),
+                         ('MINUTELY', 0))
+        self.assertEqual(self.check(30*86400, 0, 30),
+                         ('SECONDLY', mdates.SECONDS_PER_DAY))
+
+    def test_365_days(self):
+        self.assertEqual(self.check(1, 0, 365), ('MONTHLY', 12))
+        self.assertEqual(self.check(13, 0, 365), ('DAILY', 365))
+        self.assertEqual(self.check(365, 0, 365), ('HOURLY', 15))
+        self.assertEqual(self.check(365*24, 0, 365),
+                         ('MINUTELY', 0))
+        self.assertEqual(self.check(365*86400, 0, 365),
+                         ('SECONDLY', mdates.SECONDS_PER_DAY))
+
+    def test_10_years(self):
+        self.assertEqual(self.check(1, 0, 10*365),
+                         ('YEARLY', 10))
+        self.assertEqual(self.check(10, 0, 10*365),
+                         ('MONTHLY', 121))
+        self.assertEqual(self.check(122, 0, 10*365),
+                         ('DAILY', 10*365))
+        self.assertEqual(self.check(10*365, 0, 10*365),
+                         ('HOURLY', 152))
+        self.assertEqual(self.check(10*365*24, 0, 10*365),
+                         ('MINUTELY', 2))
+        self.assertEqual(self.check(10*365*86400, 0, 10*365),
+                         ('SECONDLY', mdates.SECONDS_PER_DAY))
+
+
+class Test_tick_values(unittest.TestCase):
+    def setUp(self):
+        self.date_unit = 'days since 2004-01-01 00:00'
+        self.calendar = '365_day'
+
+    def check(self, max_n_ticks, num1, num2):
+        locator = NetCDFTimeDateLocator(max_n_ticks=max_n_ticks,
+                                        calendar=self.calendar,
+                                        date_unit=self.date_unit)
+        return locator.tick_values(num1, num2)
+
+    def test_secondly(self):
+        np.testing.assert_array_almost_equal(
+            self.check(3, 0, 0.0004), [0., 0.00023148, 0.00046296])
+
+    def test_minutely(self):
+        np.testing.assert_array_almost_equal(
+            self.check(4, 1, 1.07), [1., 1.02777778, 1.05555556, 1.08333333])
+
+    def test_hourly(self):
+        np.testing.assert_array_almost_equal(
+            self.check(4, 2, 3), [2., 2.33333333, 2.66666667, 3.])
+
+    def test_daily(self):
+        np.testing.assert_array_equal(
+            self.check(5, 0, 30), [0., 7., 14., 21., 28., 35.])
+
+    def test_monthly(self):
+        np.testing.assert_array_equal(
+            self.check(4, 0, 365), [31., 120., 212., 304., 396.])
+
+    def test_yearly(self):
+        np.testing.assert_array_equal(
+            self.check(5, 0, 5*365), [31., 638., 1246., 1856.])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds some unit tests.

In future I want to extend the unit testing for `NetCDFTimeConverter.axisinfo`, `NetCDFTimeConverter.default_units` and `NetCDFTimeDateFormatter` (specifically the `__call__ `method)