### PR TITLE
Use container of nc datetime and calendar.

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -6,7 +6,7 @@ Support for netcdftime axis in matplotlib.
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa
 
-from collections import namedtuple, Iterable
+from collections import namedtuple
 import datetime
 
 import matplotlib.dates as mdates
@@ -248,17 +248,21 @@ class NetCDFTimeConverter(mdates.DateConverter):
                 return value
             first_value = value
 
+        if not isinstance(first_value, CalendarDateTime):
+            msg = 'The value must be a number, a sequence of numbers or of ' \
+                  'type :class:`nc_time_axis.CalendarDateTime.'
+            raise ValueError(msg)
+
         if not isinstance(first_value.datetime, netcdftime.datetime):
             raise ValueError('The datetime attribute of the CalendarDateTime '
                              'object must be of type `netcdftime.datetime`.')
 
         ut = netcdftime.utime(cls.standard_unit, calendar=first_value.calendar)
 
-        if isinstance(value, Iterable):
-            num = ut.date2num([v.datetime for v in value])
-        else:
-            num = ut.date2num(value.datetime)
-        return num
+        if isinstance(value, CalendarDateTime):
+            value = [value]
+
+        return ut.date2num([v.datetime for v in value])
 
 
 # Automatically register NetCDFTimeConverter with matplotlib.unit's converter

--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -249,9 +249,8 @@ class NetCDFTimeConverter(mdates.DateConverter):
             first_value = value
 
         if not isinstance(first_value, CalendarDateTime):
-            msg = 'The value must be a number, a sequence of numbers or of ' \
-                  'type :class:`nc_time_axis.CalendarDateTime.'
-            raise ValueError(msg)
+            raise ValueError('The values must be numbers or instances of '
+                             '"nc_time_axis.CalendarDateTime".')
 
         if not isinstance(first_value.datetime, netcdftime.datetime):
             raise ValueError('The datetime attribute of the CalendarDateTime '

--- a/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -71,8 +71,8 @@ class Test_convert(unittest.TestCase):
 
     def test_non_CalendarDateTime(self):
         val = netcdftime.datetime(1988, 5, 6)
-        msg = 'The value must be a number, a sequence of numbers or of ' \
-              'type :class:`nc_time_axis.CalendarDateTime.'
+        msg = 'The values must be numbers or instances of ' \
+              '"nc_time_axis.CalendarDateTime".'
         with self.assertRaisesRegexp(ValueError, msg):
             result = NetCDFTimeConverter().convert(val, None, None)
 

--- a/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -8,32 +8,31 @@ import unittest
 import netcdftime
 import numpy as np
 
-from nc_time_axis import NetCDFTimeConverter
+from nc_time_axis import NetCDFTimeConverter, CalendarDateTime
 
 
 class Test_axisinfo(unittest.TestCase):
-    def test_default_limits(self):
-        unit = ('360_day', 'days since 2000-02-25 00:00:00')
+    def test_axis_default_limits(self):
+        cal = '360_day'
+        unit = (cal, 'days since 2000-02-25 00:00:00')
         result = NetCDFTimeConverter().axisinfo(unit, None)
-        np.testing.assert_array_equal(result.default_limits,
-                                      [netcdftime.datetime(2000, 1, 1),
-                                       netcdftime.datetime(2010, 1, 1)])
+        expected_dt = [netcdftime.datetime(2000, 1, 1),
+                       netcdftime.datetime(2010, 1, 1)]
+        np.testing.assert_array_equal(
+            [cal_dt.datetime for cal_dt in result.default_limits],
+            expected_dt)
+        np.testing.assert_array_equal(
+            [cal_dt.calendar for cal_dt in result.default_limits],
+            [cal, cal])
 
 
 class Test_default_units(unittest.TestCase):
     def test_360_day_calendar(self):
         calendar = '360_day'
         unit = 'days since 2000-01-01'
-        val = [netcdftime.datetime(2014, 8, 12)]
-        val[0].calendar = calendar
+        val = [CalendarDateTime(netcdftime.datetime(2014, 8, 12), calendar)]
         result = NetCDFTimeConverter().default_units(val, None)
         self.assertEqual(result, (calendar, unit))
-
-    def test_no_calendar_attribute(self):
-        val = [netcdftime.datetime(2014, 8, 12)]
-        msg = 'Expecting netcdftimes with an extra "calendar" attribute.'
-        with self.assertRaisesRegexp(ValueError, msg):
-            result = NetCDFTimeConverter().default_units(val, None)
 
 
 class Test_convert(unittest.TestCase):
@@ -53,21 +52,20 @@ class Test_convert(unittest.TestCase):
         np.testing.assert_array_equal(result, val)
 
     def test_netcdftime(self):
-        val = netcdftime.datetime(2014, 8, 12)
-        val.calendar = '365_day'
+        val = CalendarDateTime(netcdftime.datetime(2014, 8, 12), '365_day')
         result = NetCDFTimeConverter().convert(val, None, None)
         np.testing.assert_array_equal(result, 5333.)
 
     def test_netcdftime_np_array(self):
-        val = np.array([netcdftime.datetime(2012, 6, 4)], dtype=np.object)
-        for date in val:
-            date.calendar = '360_day'
+        val = np.array([CalendarDateTime(netcdftime.datetime(2012, 6, 4),
+                                         '360_day')], dtype=np.object)
         result = NetCDFTimeConverter().convert(val, None, None)
         self.assertEqual(result, np.array([4473.]))
 
-    def test_no_calendar_attribute(self):
-        val = netcdftime.datetime(2014, 8, 12)
-        msg = 'A "calendar" attribute must be attached'
+    def test_non_netcdftime_datetime(self):
+        val = CalendarDateTime(4, '360_day')
+        msg = 'The datetime attribute of the CalendarDateTime object must ' \
+              'be of type `netcdftime.datetime`.'
         with self.assertRaisesRegexp(ValueError, msg):
             result = NetCDFTimeConverter().convert(val, None, None)
 

--- a/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -69,6 +69,13 @@ class Test_convert(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError, msg):
             result = NetCDFTimeConverter().convert(val, None, None)
 
+    def test_non_CalendarDateTime(self):
+        val = netcdftime.datetime(1988, 5, 6)
+        msg = 'The value must be a number, a sequence of numbers or of ' \
+              'type :class:`nc_time_axis.CalendarDateTime.'
+        with self.assertRaisesRegexp(ValueError, msg):
+            result = NetCDFTimeConverter().convert(val, None, None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
@@ -87,12 +87,12 @@ class Test_tick_values(unittest.TestCase):
 
     def test_secondly(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 0, 0.0004),
-            [0., 0.00015046, 0.00030093, 0.00045139])
+            self.check(6, 0, 0.0004),
+            [0, 0.00008, 0.00016, 0.00024, 0.00032, 0.0004])
 
     def test_minutely(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 1, 1.07), [1., 1.02, 1.04, 1.06, 1.08])
+            self.check(4, 1, 1.07), [0.975, 1., 1.025, 1.05, 1.075])
 
     def test_hourly(self):
         np.testing.assert_array_almost_equal(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
 mock
-netcdf4=1.0.2
+netcdf4>=1.1
 numpy
 pep8


### PR DESCRIPTION
To integrate this with Iris, we want to make use of the newer version of netcdf4.

New netcdf4 has slightly different behaviour, e.g. differing number results; not allowing you to add a calendar attribute to netcdftime.datetime object (See [PR6 comment ](https://github.com/SciTools/nc-time-axis/pull/6#issuecomment-229050703) for more detail)

This adds a container for the netcdftime.datetime object and associated calendar object, then registers that container with matplotlib.units instead.