### PR TITLE
fix compare bug

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -231,7 +231,7 @@ class NetCDFTimeConverter(mdates.DateConverter):
             if isinstance(sample_point, np.ndarray):
                 sample_point = sample_point.reshape(-1)
             calendars = np.array([point.calendar for point in sample_point])
-            if np.all(calendars[0] == calendars):
+            if np.all(calendars == calendars[0]):
                 calendar = calendars[0]
             else:
                 raise ValueError('Calendar units are not all equal.')

--- a/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
@@ -92,11 +92,11 @@ class Test_tick_values(unittest.TestCase):
 
     def test_minutely(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 1, 1.07), [1., 1.027778, 1.055556, 1.083333])
+            self.check(4, 1, 1.07), [0.986111,  1.006944,  1.027778,  1.048611,  1.069444,  1.090278])
 
     def test_hourly(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 2, 3), [2., 2.333333, 2.666667, 3.])
+            self.check(4, 2, 3), [1.916667,  2.166667,  2.416667,  2.666667,  2.916667,  3.166667])
 
     def test_daily(self):
         np.testing.assert_array_equal(
@@ -108,7 +108,7 @@ class Test_tick_values(unittest.TestCase):
 
     def test_yearly(self):
         np.testing.assert_array_equal(
-            self.check(5, 0, 5*365), [31., 638., 1246., 1856.])
+            self.check(5, 0, 5*365), [31.,   485.,   942.,  1399.,  1856.])
 
 
 if __name__ == "__main__":

--- a/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
@@ -92,11 +92,13 @@ class Test_tick_values(unittest.TestCase):
 
     def test_minutely(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 1, 1.07), [0.986111,  1.006944,  1.027778,  1.048611,  1.069444,  1.090278])
+            self.check(4, 1, 1.07), [0.986111, 1.006944, 1.027778,
+                                     1.048611, 1.069444, 1.090278])
 
     def test_hourly(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 2, 3), [1.916667,  2.166667,  2.416667,  2.666667,  2.916667,  3.166667])
+            self.check(4, 2, 3), [1.916667, 2.166667, 2.416667,
+                                  2.666667, 2.916667, 3.166667])
 
     def test_daily(self):
         np.testing.assert_array_equal(

--- a/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
@@ -92,13 +92,11 @@ class Test_tick_values(unittest.TestCase):
 
     def test_minutely(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 1, 1.07), [0.986111, 1.006944, 1.027778,
-                                     1.048611, 1.069444, 1.090278])
+            self.check(4, 1, 1.07), [1., 1.027778, 1.055556, 1.083333])
 
     def test_hourly(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 2, 3), [1.916667, 2.166667, 2.416667,
-                                  2.666667, 2.916667, 3.166667])
+            self.check(4, 2, 3), [2., 2.333333, 2.666667, 3.])
 
     def test_daily(self):
         np.testing.assert_array_equal(
@@ -110,7 +108,7 @@ class Test_tick_values(unittest.TestCase):
 
     def test_yearly(self):
         np.testing.assert_array_equal(
-            self.check(5, 0, 5*365), [31.,   485.,   942.,  1399.,  1856.])
+            self.check(5, 0, 5*365), [31., 638., 1246., 1856.])
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib
+matplotlib<2
 mock
 netcdf4>=1.1
 numpy


### PR DESCRIPTION
this is a subtle bug

for certain configurations of python and numpy 

```
calendars[0] == calendars
```
returns `False`, whilst
```
calendars == calendars[0]
```
returns `array([ True,  True,], dtype=bool)`

therefore
```
np.all(calendars[0] == calendars)
```
returns `False`, whilst 
```
np.all(calendars == calendars[0])
```
returns `True`


as type coercion, where it occurs, tends to happen left to right, this order is safer