### PR TITLE
Add support for plotting subclasses of cftime.datetime

### DIFF
--- a/nc_time_axis/tests/integration/test_plot.py
+++ b/nc_time_axis/tests/integration/test_plot.py
@@ -25,7 +25,7 @@ class Test(unittest.TestCase):
         # in an odd state, so we make sure it's been disposed of.
         plt.close('all')
 
-    def test_360_day_calendar(self):
+    def test_360_day_calendar_CalendarDateTime(self):
         datetimes = [cftime.datetime(1986, month, 30)
                      for month in range(1, 6)]
         cal_datetimes = [nc_time_axis.CalendarDateTime(dt, '360_day')
@@ -33,6 +33,13 @@ class Test(unittest.TestCase):
         line1, = plt.plot(cal_datetimes)
         result_ydata = line1.get_ydata()
         np.testing.assert_array_equal(result_ydata, cal_datetimes)
+
+    def test_360_day_calendar_raw_dates(self):
+        datetimes = [cftime.Datetime360Day(1986, month, 30)
+                     for month in range(1, 6)]
+        line1, = plt.plot(datetimes)
+        result_ydata = line1.get_ydata()
+        np.testing.assert_array_equal(result_ydata, datetimes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We would love to use nc-time-axis in xarray.  There was [some discussion over the summer](
https://github.com/pydata/xarray/issues/2164#issuecomment-404830736) about possibly adding support for plotting subclasses of `cftime.datetime` (e.g. `cftime.DatetimeNoLeap`) directly.  This would make using it in xarray somewhat easier.  This PR is an attempt to add that.  In so doing, I've retained support for plotting `nc_time_axis.CalendarDateTime` objects, so this should be backwards-compatible.

Let me know if there is still interest in this.  I'm happy to iterate on it if desired.

For example, with this PR one can now do something like this:
```python
import random

import matplotlib.pyplot as plt
import nc_time_axis
import cftime

d_time = [cftime.Datetime360Day(year=2017, month=2, day=n) for n in range(1, 31)]
temperatures = [round(random.uniform(0, 12), 3) for _ in range(len(d_time))]

plt.plot(d_time, temperatures)
plt.margins(0.1)
plt.ylim(0, 12)
plt.xlabel("Date")
plt.ylabel("Temperature")
plt.show()
```
![image](https://user-images.githubusercontent.com/6628425/50461459-8250ab00-094c-11e9-8d47-1d50dc76419b.png)