### PR TITLE
Add compatibility for change of datetime base class name in cftime

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,10 @@ Example Code
 	import nc_time_axis
 	import cftime
 
-	d_time = [cftime.datetime(year=2017, month=2, day=n) for n in range(1, 31)]
-	c_d_time = [nc_time_axis.CalendarDateTime(item, "360_day") for item in d_time]
-	temperatures = [round(random.uniform(0, 12), 3) for _ in range(len(c_d_time))]
+	d_time = [cftime.Datetime360Day(year=2017, month=2, day=n) for n in range(1, 31)]
+	temperatures = [round(random.uniform(0, 12), 3) for _ in range(len(d_time))]
 
-	plt.plot(c_d_time, temperatures)
+	plt.plot(d_time, temperatures)
 	plt.margins(0.1)
 	plt.ylim(0, 12)
 	plt.xlabel("Date")

--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -15,6 +15,11 @@ import matplotlib.units as munits
 import cftime
 import numpy as np
 
+try:
+    from cftime import datetime_base as cftime_datetime
+except ImportError:
+    from cftime import datetime as cftime_datetime
+
 # Define __version__ based on versioneer's interpretation.
 from ._version import get_versions
 __version__ = get_versions()['version']
@@ -27,7 +32,7 @@ FormatOption = namedtuple('FormatOption', ['lower', 'upper', 'format_string'])
 
 class CalendarDateTime(object):
     """
-    Container for :class:`cftime.datetime` object and calendar.
+    Container for ``cftime`` datetime object and calendar.
 
     """
     def __init__(self, datetime, calendar):
@@ -49,7 +54,7 @@ class CalendarDateTime(object):
 
 class NetCDFTimeDateFormatter(mticker.Formatter):
     """
-    Formatter for cftime.datetime data.
+    Formatter for cftime datetime data.
 
     """
     # Some magic numbers. These seem to work pretty well.
@@ -87,7 +92,7 @@ class NetCDFTimeDateFormatter(mticker.Formatter):
 
 class NetCDFTimeDateLocator(mticker.Locator):
     """
-    Determines tick locations when plotting cftime.datetime data.
+    Determines tick locations when plotting cftime datetime data.
 
     """
     def __init__(self, max_n_ticks, calendar, date_unit, min_n_ticks=3):
@@ -153,7 +158,7 @@ class NetCDFTimeDateLocator(mticker.Locator):
             # TODO START AT THE BEGINNING OF A DECADE/CENTURY/MILLENIUM as
             # appropriate.
             years = self._max_n_locator.tick_values(lower.year, upper.year)
-            ticks = [cftime.datetime(int(year), 1, 1) for year in years]
+            ticks = [cftime_datetime(int(year), 1, 1) for year in years]
         elif resolution == 'MONTHLY':
             # TODO START AT THE BEGINNING OF A DECADE/CENTURY/MILLENIUM as
             # appropriate.
@@ -162,7 +167,7 @@ class NetCDFTimeDateLocator(mticker.Locator):
             for offset in months_offset:
                 year = lower.year + np.floor((lower.month + offset) / 12)
                 month = ((lower.month + offset) % 12) + 1
-                ticks.append(cftime.datetime(int(year), int(month), 1))
+                ticks.append(cftime_datetime(int(year), int(month), 1))
         elif resolution == 'DAILY':
             # TODO: It would be great if this favoured multiples of 7.
             days = self._max_n_locator_days.tick_values(vmin, vmax)
@@ -196,7 +201,7 @@ class NetCDFTimeDateLocator(mticker.Locator):
 
 class NetCDFTimeConverter(mdates.DateConverter):
     """
-    Converter for cftime.datetime data.
+    Converter for cftime datetime data.
 
     """
     standard_unit = 'days since 2000-01-01'
@@ -216,9 +221,9 @@ class NetCDFTimeConverter(mdates.DateConverter):
         majfmt = NetCDFTimeDateFormatter(majloc, calendar=calendar,
                                          time_units=date_unit)
         if date_type is CalendarDateTime:
-            datemin = CalendarDateTime(cftime.datetime(2000, 1, 1),
+            datemin = CalendarDateTime(cftime_datetime(2000, 1, 1),
                                        calendar=calendar)
-            datemax = CalendarDateTime(cftime.datetime(2010, 1, 1),
+            datemax = CalendarDateTime(cftime_datetime(2010, 1, 1),
                                        calendar=calendar)
         else:
             datemin = date_type(2000, 1, 1)
@@ -274,20 +279,20 @@ class NetCDFTimeConverter(mdates.DateConverter):
                 return value
             first_value = value
 
-        if not isinstance(first_value, (CalendarDateTime, cftime.datetime)):
+        if not isinstance(first_value, (CalendarDateTime, cftime_datetime)):
             raise ValueError('The values must be numbers or instances of '
                              '"nc_time_axis.CalendarDateTime" or '
-                             '"cftime.datetime".')
+                             '"cftime datetime".')
 
         if isinstance(first_value, CalendarDateTime):
-            if not isinstance(first_value.datetime, cftime.datetime):
+            if not isinstance(first_value.datetime, cftime_datetime):
                 raise ValueError('The datetime attribute of the '
                                  'CalendarDateTime object must be of type '
-                                 '`cftime.datetime`.')
+                                 '`cftime.datetime_base`.')
 
         ut = cftime.utime(cls.standard_unit, calendar=first_value.calendar)
 
-        if isinstance(value, (CalendarDateTime, cftime.datetime)):
+        if isinstance(value, (CalendarDateTime, cftime_datetime)):
             value = [value]
 
         if isinstance(first_value, CalendarDateTime):

--- a/nc_time_axis/tests/integration/test_plot.py
+++ b/nc_time_axis/tests/integration/test_plot.py
@@ -11,6 +11,11 @@ import matplotlib.pyplot as plt  # nopep8
 import cftime  # nopep8
 import numpy as np  # nopep8
 
+try:
+    from cftime import datetime_base as cftime_datetime
+except ImportError:
+    from cftime import datetime as cftime_datetime
+
 import nc_time_axis  # nopep8
 
 
@@ -26,7 +31,7 @@ class Test(unittest.TestCase):
         plt.close('all')
 
     def test_360_day_calendar_CalendarDateTime(self):
-        datetimes = [cftime.datetime(1986, month, 30)
+        datetimes = [cftime_datetime(1986, month, 30)
                      for month in range(1, 6)]
         cal_datetimes = [nc_time_axis.CalendarDateTime(dt, '360_day')
                          for dt in datetimes]

--- a/nc_time_axis/tests/unit/test_CalendarDateTime.py
+++ b/nc_time_axis/tests/unit/test_CalendarDateTime.py
@@ -7,24 +7,29 @@ import unittest
 
 import cftime
 
+try:
+    from cftime import datetime_base as cftime_datetime
+except ImportError:
+    from cftime import datetime as cftime_datetime
+
 from nc_time_axis import CalendarDateTime
 
 
 class Test___eq__(unittest.TestCase):
     def setUp(self):
-        self.cdt = CalendarDateTime(cftime.datetime(1967, 7, 22, 3, 6),
+        self.cdt = CalendarDateTime(cftime_datetime(1967, 7, 22, 3, 6),
                                     '360_day')
 
     def test_equal(self):
         self.assertTrue(self.cdt == self.cdt)
 
     def test_diff_cal(self):
-        other_cdt = CalendarDateTime(cftime.datetime(1967, 7, 22, 3, 6),
+        other_cdt = CalendarDateTime(cftime_datetime(1967, 7, 22, 3, 6),
                                      '365_day')
         self.assertFalse(self.cdt == other_cdt)
 
     def test_diff_datetime(self):
-        other_cdt = CalendarDateTime(cftime.datetime(1992, 11, 23, 3, 6),
+        other_cdt = CalendarDateTime(cftime_datetime(1992, 11, 23, 3, 6),
                                      '360_day')
         self.assertFalse(self.cdt == other_cdt)
 
@@ -34,19 +39,19 @@ class Test___eq__(unittest.TestCase):
 
 class Test__ne__(unittest.TestCase):
     def setUp(self):
-        self.cdt = CalendarDateTime(cftime.datetime(1967, 7, 22, 3, 6),
+        self.cdt = CalendarDateTime(cftime_datetime(1967, 7, 22, 3, 6),
                                     '360_day')
 
     def test_equal(self):
         self.assertFalse(self.cdt != self.cdt)
 
     def test_diff_cal(self):
-        other_cdt = CalendarDateTime(cftime.datetime(1967, 7, 22, 3, 6),
+        other_cdt = CalendarDateTime(cftime_datetime(1967, 7, 22, 3, 6),
                                      '365_day')
         self.assertTrue(self.cdt != other_cdt)
 
     def test_diff_datetime(self):
-        other_cdt = CalendarDateTime(cftime.datetime(1992, 11, 23, 3, 6),
+        other_cdt = CalendarDateTime(cftime_datetime(1992, 11, 23, 3, 6),
                                      '360_day')
         self.assertTrue(self.cdt != other_cdt)
 

--- a/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -9,6 +9,10 @@ import unittest
 import cftime
 import numpy as np
 
+try:
+    from cftime import datetime_base as cftime_datetime
+except ImportError:
+    from cftime import datetime as cftime_datetime
 from nc_time_axis import NetCDFTimeConverter, CalendarDateTime
 
 
@@ -17,8 +21,8 @@ class Test_axisinfo(unittest.TestCase):
         cal = '360_day'
         unit = (cal, 'days since 2000-02-25 00:00:00', CalendarDateTime)
         result = NetCDFTimeConverter().axisinfo(unit, None)
-        expected_dt = [cftime.datetime(2000, 1, 1),
-                       cftime.datetime(2010, 1, 1)]
+        expected_dt = [cftime_datetime(2000, 1, 1),
+                       cftime_datetime(2010, 1, 1)]
         np.testing.assert_array_equal(
             result.default_limits,
             [CalendarDateTime(edt, cal) for edt in expected_dt])
@@ -28,14 +32,14 @@ class Test_default_units(unittest.TestCase):
     def test_360_day_calendar_point_CalendarDateTime(self):
         calendar = '360_day'
         unit = 'days since 2000-01-01'
-        val = CalendarDateTime(cftime.datetime(2014, 8, 12), calendar)
+        val = CalendarDateTime(cftime_datetime(2014, 8, 12), calendar)
         result = NetCDFTimeConverter().default_units(val, None)
         self.assertEqual(result, (calendar, unit, CalendarDateTime))
 
     def test_360_day_calendar_list_CalendarDateTime(self):
         calendar = '360_day'
         unit = 'days since 2000-01-01'
-        val = [CalendarDateTime(cftime.datetime(2014, 8, 12), calendar)]
+        val = [CalendarDateTime(cftime_datetime(2014, 8, 12), calendar)]
         result = NetCDFTimeConverter().default_units(val, None)
         self.assertEqual(result, (calendar, unit, CalendarDateTime))
 
@@ -43,9 +47,9 @@ class Test_default_units(unittest.TestCase):
         # Test the case where the input is an nd-array.
         calendar = '360_day'
         unit = 'days since 2000-01-01'
-        val = np.array([[CalendarDateTime(cftime.datetime(2014, 8, 12),
+        val = np.array([[CalendarDateTime(cftime_datetime(2014, 8, 12),
                                           calendar)],
-                       [CalendarDateTime(cftime.datetime(2014, 8, 13),
+                       [CalendarDateTime(cftime_datetime(2014, 8, 13),
                                          calendar)]])
         result = NetCDFTimeConverter().default_units(val, None)
         self.assertEqual(result, (calendar, unit, CalendarDateTime))
@@ -78,8 +82,8 @@ class Test_default_units(unittest.TestCase):
         calendar_1 = '360_day'
         calendar_2 = '365_day'
         unit = 'days since 2000-01-01'
-        val = [CalendarDateTime(cftime.datetime(2014, 8, 12), calendar_1),
-               CalendarDateTime(cftime.datetime(2014, 8, 13), calendar_2)]
+        val = [CalendarDateTime(cftime_datetime(2014, 8, 12), calendar_1),
+               CalendarDateTime(cftime_datetime(2014, 8, 13), calendar_2)]
         with assertRaisesRegex(self, ValueError, 'not all equal'):
             NetCDFTimeConverter().default_units(val, None)
 
@@ -108,7 +112,7 @@ class Test_convert(unittest.TestCase):
         np.testing.assert_array_equal(result, val)
 
     def test_cftime_CalendarDateTime(self):
-        val = CalendarDateTime(cftime.datetime(2014, 8, 12), '365_day')
+        val = CalendarDateTime(cftime_datetime(2014, 8, 12), '365_day')
         result = NetCDFTimeConverter().convert(val, None, None)
         np.testing.assert_array_equal(result, 5333.)
 
@@ -118,7 +122,7 @@ class Test_convert(unittest.TestCase):
         np.testing.assert_array_equal(result, 5333.)
 
     def test_cftime_np_array_CalendarDateTime(self):
-        val = np.array([CalendarDateTime(cftime.datetime(2012, 6, 4),
+        val = np.array([CalendarDateTime(cftime_datetime(2012, 6, 4),
                                          '360_day')], dtype=np.object)
         result = NetCDFTimeConverter().convert(val, None, None)
         self.assertEqual(result, np.array([4473.]))
@@ -131,7 +135,7 @@ class Test_convert(unittest.TestCase):
     def test_non_cftime_datetime(self):
         val = CalendarDateTime(4, '360_day')
         msg = 'The datetime attribute of the CalendarDateTime object must ' \
-              'be of type `cftime.datetime`.'
+              'be of type `cftime.datetime_base`.'
         with assertRaisesRegex(self, ValueError, msg):
             result = NetCDFTimeConverter().convert(val, None, None)
 


### PR DESCRIPTION
`cftime` is planning on renaming the base class for its datetime objects from `cftime.datetime` to `cftime.datetime_base`.  See discussion in https://github.com/Unidata/cftime/issues/198 and https://github.com/Unidata/cftime/pull/199.  This PR adds the appropriate logic in nc-time-axis to handle this in a backwards-compatible way.  