### PR TITLE
use object instead of np.object

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -271,7 +271,7 @@ class NetCDFTimeConverter(mdates.DateConverter):
         shape = None
         if isinstance(value, np.ndarray):
             # Don't do anything with numeric types.
-            if value.dtype != np.object:
+            if value.dtype != object:
                 return value
             shape = value.shape
             value = value.reshape(-1)

--- a/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -119,12 +119,12 @@ class Test_convert(unittest.TestCase):
 
     def test_cftime_np_array_CalendarDateTime(self):
         val = np.array([CalendarDateTime(cftime.datetime(2012, 6, 4),
-                                         '360_day')], dtype=np.object)
+                                         '360_day')], dtype=object)
         result = NetCDFTimeConverter().convert(val, None, None)
         self.assertEqual(result, np.array([4473.]))
 
     def test_cftime_np_array_raw_date(self):
-        val = np.array([cftime.Datetime360Day(2012, 6, 4)], dtype=np.object)
+        val = np.array([cftime.Datetime360Day(2012, 6, 4)], dtype=object)
         result = NetCDFTimeConverter().convert(val, None, None)
         self.assertEqual(result, np.array([4473.]))
 


### PR DESCRIPTION
From the xarray test suite:

```python-traceback
DeprecationWarning: `np.object` is a deprecated alias for the builtin `object`.
To silence this warning, use `object` by itself. Doing this will not modify any behavior and is safe.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

ref: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations