### PR TITLE
min pin for cftime

### DIFF
--- a/requirements/py37.yml
+++ b/requirements/py37.yml
@@ -11,13 +11,13 @@ dependencies:
   - setuptools-scm
 
 # core dependencies
-  - cftime
+  - cftime >=1.5
   - matplotlib
   - numpy
 
 # test dependencies
   - codecov
-  - pytest>=6.0
+  - pytest >=6.0
   - pytest-cov
 
 # dev dependencies

--- a/requirements/py38.yml
+++ b/requirements/py38.yml
@@ -11,13 +11,13 @@ dependencies:
   - setuptools-scm
 
 # core dependencies
-  - cftime
+  - cftime >=1.5
   - matplotlib
   - numpy
 
 # test dependencies
   - codecov
-  - pytest>=6.0
+  - pytest >=6.0
   - pytest-cov
 
 # dev dependencies

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -11,13 +11,13 @@ dependencies:
   - setuptools-scm
 
 # core dependencies
-  - cftime
+  - cftime >=1.5
   - matplotlib
   - numpy
 
 # test dependencies
   - codecov
-  - pytest>=6.0
+  - pytest >=6.0
   - pytest-cov
 
 # dev dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ version = attr: nc_time_axis.__version__
 [options]
 include_package_data = True
 install_requires =
-    cftime
+    cftime >=1.5
     matplotlib
     numpy
 packages = find:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
This PR introduced a minimum pin of `cftime>=1.5`, otherwise it is possible for `nc-time-axis` 1.13.0 to be resolved with an incompatible version of `cftime` within a `conda`/`pip` environment
