### PR TITLE
Fix for axis labels near year zero

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -173,6 +173,7 @@ class NetCDFTimeDateLocator(mticker.Locator):
             # appropriate.
 
             years = self._max_n_locator.tick_values(lower.year, upper.year)
+            years = [1 if x == 0 else x for x in years]
             ticks = [
                 cftime.datetime(
                     int(year),
@@ -190,6 +191,7 @@ class NetCDFTimeDateLocator(mticker.Locator):
             ticks = []
             for offset in months_offset:
                 year = lower.year + np.floor((lower.month + offset) / 12)
+                year = 1 if year == 0 else year
                 month = ((lower.month + offset) % 12) + 1
                 dt = cftime.datetime(
                     int(year),


### PR DESCRIPTION
Addresses issue when `max_n_locator.tick_values()` returns the invalid year 0

## 🚀 Pull Request

### Description
When attempting to plot a time series beginning in model year 1, `max_n_locator.tick_values()` sometimes returns year 0. Since this is an invalid year, the following error results:

```
~/miniconda3/envs/py39/lib/python3.9/site-packages/nc_time_axis/__init__.py in <listcomp>(.0)
    155             years = self._max_n_locator.tick_values(lower.year, upper.year)
    156             #years = [1 if x == 0 else x for x in years]
--> 157             ticks = [cftime.datetime(int(year), 1, 1) for year in years]
    158         elif resolution == 'MONTHLY':
    159             # TODO START AT THE BEGINNING OF A DECADE/CENTURY/MILLENIUM as

src/cftime/_cftime.pyx in cftime._cftime.datetime.__init__()

src/cftime/_cftime.pyx in cftime._cftime.assert_valid_date()

ValueError: invalid year provided in cftime.datetime(0, 1, 1, 0, 0, 0, 0, calendar='gregorian')
```

This fix replaces `year = 0` with `year = 1` if zero is returned a possible tick location.
