### PR TITLE
Fix NetCDFTimeConverter.convert with list

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -343,9 +343,11 @@ class NetCDFTimeConverter(mdates.DateConverter):
             # Don't do anything with numeric types.
             if munits.ConversionInterface.is_numlike(value):
                 return value
+            # Not an array but a list of non-numerical types (thus assuming datetime types)
             elif isinstance(value, (list, tuple)):
                 first_value = value[0]
             else:
+                # Neither numerical, list or ndarray : must be a datetime scalar.
                 first_value = value
 
         if not isinstance(first_value, (CalendarDateTime, cftime.datetime)):

--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -343,7 +343,10 @@ class NetCDFTimeConverter(mdates.DateConverter):
             # Don't do anything with numeric types.
             if munits.ConversionInterface.is_numlike(value):
                 return value
-            first_value = value
+            elif isinstance(value, (list, tuple)):
+                first_value = value[0]
+            else:
+                first_value = value
 
         if not isinstance(first_value, (CalendarDateTime, cftime.datetime)):
             raise ValueError(
@@ -361,7 +364,7 @@ class NetCDFTimeConverter(mdates.DateConverter):
                 )
 
         if isinstance(first_value, CalendarDateTime):
-            if isinstance(value, np.ndarray):
+            if isinstance(value, (np.ndarray, list, tuple)):
                 value = [v.datetime for v in value]
             else:
                 value = value.datetime

--- a/nc_time_axis/tests/integration/test_plot.py
+++ b/nc_time_axis/tests/integration/test_plot.py
@@ -44,6 +44,17 @@ class Test(unittest.TestCase):
         result_ydata = line1.get_ydata()
         np.testing.assert_array_equal(result_ydata, datetimes)
 
+    def test_fill_between(self):
+        calendar = "360_day"
+        dt = [
+            cftime.datetime(year=2017, month=2, day=day, calendar=calendar)
+            for day in range(1, 31)
+        ]
+        cdt = [nc_time_axis.CalendarDateTime(item, calendar) for item in dt]
+        temperatures = [np.round(np.random.uniform(0, 12), 3) for _ in range(len(cdt))]
+
+        plt.fill_between(cdt, temperatures, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/nc_time_axis/tests/integration/test_plot.py
+++ b/nc_time_axis/tests/integration/test_plot.py
@@ -51,7 +51,9 @@ class Test(unittest.TestCase):
             for day in range(1, 31)
         ]
         cdt = [nc_time_axis.CalendarDateTime(item, calendar) for item in dt]
-        temperatures = [np.round(np.random.uniform(0, 12), 3) for _ in range(len(cdt))]
+        temperatures = [
+            np.round(np.random.uniform(0, 12), 3) for _ in range(len(cdt))
+        ]
 
         plt.fill_between(cdt, temperatures, 0)
 

--- a/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -134,6 +134,13 @@ class Test_convert(unittest.TestCase):
         assert result == expected
         assert len(result) == 1
 
+    def test_cftime_tuple_date(self):
+        val = (cftime.DatetimeNoLeap(2014, 8, 12),)
+        result = NetCDFTimeConverter().convert(val, None, None)
+        expected = 5333.0
+        assert result == expected
+        assert len(result) == 1
+
     def test_cftime_np_array_CalendarDateTime(self):
         val = np.array(
             [CalendarDateTime(cftime.datetime(2012, 6, 4), "360_day")],

--- a/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -127,6 +127,13 @@ class Test_convert(unittest.TestCase):
         assert result == expected
         assert np.isscalar(result)
 
+    def test_cftime_list_date(self):
+        val = [cftime.DatetimeNoLeap(2014, 8, 12)]
+        result = NetCDFTimeConverter().convert(val, None, None)
+        expected = 5333.0
+        assert result == expected
+        assert len(result) == 1
+
     def test_cftime_np_array_CalendarDateTime(self):
         val = np.array(
             [CalendarDateTime(cftime.datetime(2012, 6, 4), "360_day")],


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
Fixes #47 and fixes #74. Now `NetCDFTimeConverter.convert` accepts lists or tuples, as given by matplotlib when using `fill_between` and `axhspan` (and maybe others).

Added a unit test and an integration one.