### PR TITLE
Harmonize label format and tick resolution choosing logic

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -3,8 +3,6 @@ Support for cftime axis in matplotlib.
 
 """
 
-from collections import namedtuple
-
 import cftime
 import matplotlib.dates as mdates
 import matplotlib.ticker as mticker
@@ -13,9 +11,6 @@ import matplotlib.units as munits
 import numpy as np
 
 from ._version import version as __version__  # noqa: F401
-
-# Lower and upper are in number of days.
-FormatOption = namedtuple("FormatOption", ["lower", "upper", "format_string"])
 
 
 class CalendarDateTime:

--- a/nc_time_axis/tests/unit/test_NetCDFTimeDateFormatter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeDateFormatter.py
@@ -7,20 +7,20 @@ from nc_time_axis import NetCDFTimeDateFormatter
 
 
 class Test_pick_format(unittest.TestCase):
-    def check(self, ndays):
+    def check(self, resolution):
         locator = mock.MagicMock()
         formatter = NetCDFTimeDateFormatter(
             locator, "360_day", "days since 2000-01-01 00:00"
         )
-        return formatter.pick_format(ndays)
+        return formatter.pick_format(resolution)
 
     def test(self):
-        self.assertEqual(self.check(0.1), "%H:%M:%S")
-        self.assertEqual(self.check(0.6), "%H:%M")
-        self.assertEqual(self.check(5), "%Y-%m-%d %H:%M")
-        self.assertEqual(self.check(40), "%Y-%m-%d")
-        self.assertEqual(self.check(300), "%Y-%m")
-        self.assertEqual(self.check(1000), "%Y")
+        self.assertEqual(self.check("SECONDLY"), "%H:%M:%S")
+        self.assertEqual(self.check("MINUTELY"), "%H:%M")
+        self.assertEqual(self.check("HOURLY"), "%Y-%m-%d %H:%M")
+        self.assertEqual(self.check("DAILY"), "%Y-%m-%d")
+        self.assertEqual(self.check("MONTHLY"), "%Y-%m")
+        self.assertEqual(self.check("YEARLY"), "%Y")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🚀 Pull Request

This takes a fairly simple approach to addressing #48.  Here I define a mapping between the resolution chosen by the tick locator depending on the range and number of ticks requested, and the date format for the labels on the axis.  

The plot @klindsay28's example now produces is shown below:

![result](https://user-images.githubusercontent.com/6628425/128923330-909bc33c-52f1-41ea-b431-b286f93fcc8c.png)