### PR TITLE
Add support for plotting universal datetime objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,16 @@ Or `pip`:
 
     import cftime
     import matplotlib.pyplot as plt
-
-    from nc_time_axis import CalendarDateTime
+    import nc_time_axis
 
     calendar = "360_day"
     dt = [
         cftime.datetime(year=2017, month=2, day=day, calendar=calendar)
         for day in range(1, 31)
     ]
-    cdt = [CalendarDateTime(item, calendar) for item in dt]
-    temperatures = [round(random.uniform(0, 12), 3) for _ in range(len(cdt))]
+    temperatures = [round(random.uniform(0, 12), 3) for _ in range(len(dt))]
 
-    plt.plot(cdt, temperatures)
+    plt.plot(dt, temperatures)
     plt.margins(0.1)
     plt.ylim(0, 12)
     plt.xlabel("Date")

--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -308,6 +308,10 @@ class NetCDFTimeConverter(mdates.DateConverter):
             else:
                 calendar = sample_point.calendar
             date_type = type(sample_point)
+        if calendar == "":
+            raise ValueError(
+                "A calendar must be defined to plot dates using a cftime axis."
+            )
         return calendar, cls.standard_unit, date_type
 
     @classmethod
@@ -373,6 +377,7 @@ if CalendarDateTime not in munits.registry:
     munits.registry[CalendarDateTime] = NetCDFTimeConverter()
 
 CFTIME_TYPES = [
+    cftime.datetime,
     cftime.DatetimeNoLeap,
     cftime.DatetimeAllLeap,
     cftime.DatetimeProlepticGregorian,

--- a/nc_time_axis/tests/integration/test_plot.py
+++ b/nc_time_axis/tests/integration/test_plot.py
@@ -44,6 +44,23 @@ class Test(unittest.TestCase):
         result_ydata = line1.get_ydata()
         np.testing.assert_array_equal(result_ydata, datetimes)
 
+    def test_360_day_calendar_raw_universal_dates(self):
+        datetimes = [
+            cftime.datetime(1986, month, 30, calendar="360_day")
+            for month in range(1, 6)
+        ]
+        (line1,) = plt.plot(datetimes)
+        result_ydata = line1.get_ydata()
+        np.testing.assert_array_equal(result_ydata, datetimes)
+
+    def test_no_calendar_raw_universal_dates(self):
+        datetimes = [
+            cftime.datetime(1986, month, 30, calendar=None)
+            for month in range(1, 6)
+        ]
+        with self.assertRaisesRegex(ValueError, "defined"):
+            plt.plot(datetimes)
+
     def test_fill_between(self):
         calendar = "360_day"
         dt = [

--- a/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
@@ -83,6 +83,23 @@ class Test_compute_resolution(unittest.TestCase):
         )
 
 
+class Test_compute_resolution_universal_datetime(unittest.TestCase):
+    def check(self, max_n_ticks, num1, num2):
+        locator = NetCDFTimeDateLocator(
+            max_n_ticks=max_n_ticks,
+            calendar=self.calendar,
+            date_unit=self.date_unit,
+        )
+        date1 = cftime.num2date(num1, self.date_unit, calendar=self.calendar)
+        date2 = cftime.num2date(num2, self.date_unit, calendar=self.calendar)
+        return locator.compute_resolution(
+            num1,
+            num2,
+            cftime.datetime(*date1.timetuple(), calendar=self.calendar),
+            cftime.datetime(*date2.timetuple(), calendar=self.calendar),
+        )
+
+
 class Test_tick_values(unittest.TestCase):
     def setUp(self):
         self.date_unit = "days since 2004-01-01 00:00"


### PR DESCRIPTION
## 🚀 Pull Request

Addresses #75.  I think we can probably close #16 as well.

### Description

This makes it possible to plot cftime's universal datetime object, which was introduced in cftime 1.3.0.  The following example now works:

```python
import random

import cftime
import matplotlib.pyplot as plt
import nc_time_axis

dt = [cftime.datetime(2017, 2, day, calendar="noleap") for day in range(1, 28)]
temperatures = [round(random.uniform(0, 12), 3) for _ in range(len(dt))]
plt.plot(dt, temperatures)
```
We will raise a `ValueError` if someone tries to plot dates without a specified calendar.

I have taken the liberty to update the example in the README to follow this approach, because it is simpler than using `CalendarDateTime`.  Since nc-time-axis now requires cftime >= 1.5 (https://github.com/SciTools/nc-time-axis/pull/69), this update should be safe.