### PR TITLE
Add ability to set ticks and tick label format

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -59,9 +59,7 @@ class AutoCFTimeFormatter(mticker.Formatter):
 
     """
 
-    def __init__(
-        self, locator, calendar, time_units
-    ):
+    def __init__(self, locator, calendar, time_units):
         #: The locator associated with this formatter. This is used to get hold
         #: of the scaling information.
         self.locator = locator

--- a/nc_time_axis/tests/integration/test_plot.py
+++ b/nc_time_axis/tests/integration/test_plot.py
@@ -8,6 +8,7 @@ matplotlib.use("agg")
 import cftime
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
 import nc_time_axis
 
@@ -56,6 +57,69 @@ class Test(unittest.TestCase):
         ]
 
         plt.fill_between(cdt, temperatures, 0)
+
+
+def setup_function(function):
+    plt.close()
+
+
+def teardown_function(function):
+    plt.close()
+
+
+TICKS = {
+    "List[cftime.datetime]": [cftime.Datetime360Day(1986, 2, 1)],
+    "List[CalendarDateTime]": [
+        nc_time_axis.CalendarDateTime(
+            cftime.Datetime360Day(1986, 2, 1), "360_day"
+        )
+    ],
+}
+
+
+@pytest.mark.parametrize("axis", ["x", "y"])
+@pytest.mark.parametrize("ticks", TICKS.values(), ids=list(TICKS.keys()))
+def test_set_ticks(axis, ticks):
+    times = [cftime.Datetime360Day(1986, month, 30) for month in range(1, 6)]
+    data = range(len(times))
+    fig, ax = plt.subplots(1, 1)
+    if axis == "x":
+        ax.plot(times, data)
+        ax.set_xticks(ticks)
+        fig.canvas.draw()
+        ticklabels = ax.get_xticklabels()
+    else:
+        ax.plot(data, times)
+        ax.set_yticks(ticks)
+        fig.canvas.draw()
+        ticklabels = ax.get_yticklabels()
+    result_labels = [label.get_text() for label in ticklabels]
+    expected_labels = ["1986-02-01"]
+    assert result_labels == expected_labels
+
+
+@pytest.mark.parametrize("axis", ["x", "y"])
+@pytest.mark.parametrize("ticks", TICKS.values(), ids=list(TICKS.keys()))
+def test_set_ticks_with_CFTimeFormatter(axis, ticks):
+    times = [cftime.Datetime360Day(1986, month, 30) for month in range(1, 6)]
+    data = range(len(times))
+    fig, ax = plt.subplots(1, 1)
+    formatter = nc_time_axis.CFTimeFormatter("%Y-%m", "360_day")
+    if axis == "x":
+        ax.plot(times, data)
+        ax.set_xticks(ticks)
+        ax.xaxis.set_major_formatter(formatter)
+        fig.canvas.draw()
+        ticklabels = ax.get_xticklabels()
+    else:
+        ax.plot(data, times)
+        ax.set_yticks(ticks)
+        ax.yaxis.set_major_formatter(formatter)
+        fig.canvas.draw()
+        ticklabels = ax.get_yticklabels()
+    result_labels = [label.get_text() for label in ticklabels]
+    expected_labels = ["1986-02"]
+    assert result_labels == expected_labels
 
 
 if __name__ == "__main__":

--- a/nc_time_axis/tests/integration/test_plot.py
+++ b/nc_time_axis/tests/integration/test_plot.py
@@ -142,5 +142,6 @@ def test_set_format_with_CFTimeFormatter_with_default_ticks(axis):
     expected_labels = ["1986", "1986", "1986", "1986", "1986"]
     assert result_labels == expected_labels
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/nc_time_axis/tests/integration/test_plot.py
+++ b/nc_time_axis/tests/integration/test_plot.py
@@ -122,5 +122,25 @@ def test_set_ticks_with_CFTimeFormatter(axis, ticks):
     assert result_labels == expected_labels
 
 
+@pytest.mark.parametrize("axis", ["x", "y"])
+def test_set_format_with_CFTimeFormatter_with_default_ticks(axis):
+    times = [cftime.Datetime360Day(1986, month, 30) for month in range(1, 6)]
+    data = range(len(times))
+    fig, ax = plt.subplots(1, 1)
+    formatter = nc_time_axis.CFTimeFormatter("%Y", "360_day")
+    if axis == "x":
+        ax.plot(times, data)
+        ax.xaxis.set_major_formatter(formatter)
+        fig.canvas.draw()
+        ticklabels = ax.get_xticklabels()
+    else:
+        ax.plot(data, times)
+        ax.yaxis.set_major_formatter(formatter)
+        fig.canvas.draw()
+        ticklabels = ax.get_yticklabels()
+    result_labels = [label.get_text() for label in ticklabels]
+    expected_labels = ["1986", "1986", "1986", "1986", "1986"]
+    assert result_labels == expected_labels
+
 if __name__ == "__main__":
     unittest.main()

--- a/nc_time_axis/tests/unit/test_AutoCFTimeFormatter.py
+++ b/nc_time_axis/tests/unit/test_AutoCFTimeFormatter.py
@@ -11,9 +11,7 @@ from nc_time_axis import AutoCFTimeFormatter, NetCDFTimeDateFormatter
 class Test_pick_format(unittest.TestCase):
     def check(self, resolution):
         locator = mock.MagicMock()
-        formatter = AutoCFTimeFormatter(
-            locator, "360_day", "days since 2000-01-01 00:00"
-        )
+        formatter = AutoCFTimeFormatter(locator, "360_day")
         return formatter.pick_format(resolution)
 
     def test(self):
@@ -28,6 +26,12 @@ class Test_pick_format(unittest.TestCase):
 def test_NetCDFTimeDateFormatter_warning():
     locator = mock.MagicMock()
     with pytest.warns(FutureWarning, match="AutoCFTimeFormatter"):
+        NetCDFTimeDateFormatter(locator, "360_day", "days since 2000-01-01")
+
+
+def test_NetCDFTimeDateFormatter_time_units_warning():
+    locator = mock.MagicMock()
+    with pytest.warns(DeprecationWarning, match="time_units"):
         NetCDFTimeDateFormatter(locator, "360_day", "days since 2000-01-01")
 
 

--- a/nc_time_axis/tests/unit/test_AutoCFTimeFormatter.py
+++ b/nc_time_axis/tests/unit/test_AutoCFTimeFormatter.py
@@ -1,15 +1,17 @@
-"""Unit tests for the `nc-time-axis.NetCDFTimeDateFormatter` class."""
+"""Unit tests for the `nc_time_axis.AutoCFTimeFormatter` class."""
 
 import unittest
 import unittest.mock as mock
 
-from nc_time_axis import NetCDFTimeDateFormatter
+import pytest
+
+from nc_time_axis import AutoCFTimeFormatter, NetCDFTimeDateFormatter
 
 
 class Test_pick_format(unittest.TestCase):
     def check(self, resolution):
         locator = mock.MagicMock()
-        formatter = NetCDFTimeDateFormatter(
+        formatter = AutoCFTimeFormatter(
             locator, "360_day", "days since 2000-01-01 00:00"
         )
         return formatter.pick_format(resolution)
@@ -21,6 +23,12 @@ class Test_pick_format(unittest.TestCase):
         self.assertEqual(self.check("DAILY"), "%Y-%m-%d")
         self.assertEqual(self.check("MONTHLY"), "%Y-%m")
         self.assertEqual(self.check("YEARLY"), "%Y")
+
+
+def test_NetCDFTimeDateFormatter_warning():
+    locator = mock.MagicMock()
+    with pytest.warns(FutureWarning, match="AutoCFTimeFormatter"):
+        NetCDFTimeDateFormatter(locator, "360_day", "days since 2000-01-01")
 
 
 if __name__ == "__main__":

--- a/nc_time_axis/tests/unit/test_CFTimeFormatter.py
+++ b/nc_time_axis/tests/unit/test_CFTimeFormatter.py
@@ -3,7 +3,6 @@ import pytest
 
 from nc_time_axis import CFTimeFormatter
 
-
 FORMATS = {
     "%H:%M:%S": "01:01:01",
     "%H:%M": "01:01",

--- a/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeDateLocator.py
@@ -7,28 +7,26 @@ import cftime
 import matplotlib.dates as mdates
 import matplotlib.style
 import numpy as np
+import pytest
 
-from nc_time_axis import NetCDFTimeDateLocator
+from nc_time_axis import _TIME_UNITS, NetCDFTimeDateLocator
 
 matplotlib.style.use("classic")
 
 
 class Test_compute_resolution(unittest.TestCase):
     def setUp(self):
-        self.date_unit = "days since 2004-01-01 00:00"
         self.calendar = "365_day"
 
     def check(self, max_n_ticks, num1, num2):
         locator = NetCDFTimeDateLocator(
-            max_n_ticks=max_n_ticks,
-            calendar=self.calendar,
-            date_unit=self.date_unit,
+            max_n_ticks=max_n_ticks, calendar=self.calendar
         )
         return locator.compute_resolution(
             num1,
             num2,
-            cftime.num2date(num1, self.date_unit, calendar=self.calendar),
-            cftime.num2date(num2, self.date_unit, calendar=self.calendar),
+            cftime.num2date(num1, _TIME_UNITS, calendar=self.calendar),
+            cftime.num2date(num2, _TIME_UNITS, calendar=self.calendar),
         )
 
     def test_one_minute(self):
@@ -85,14 +83,11 @@ class Test_compute_resolution(unittest.TestCase):
 
 class Test_tick_values(unittest.TestCase):
     def setUp(self):
-        self.date_unit = "days since 2004-01-01 00:00"
         self.calendar = "365_day"
 
     def check(self, max_n_ticks, num1, num2):
         locator = NetCDFTimeDateLocator(
-            max_n_ticks=max_n_ticks,
-            calendar=self.calendar,
-            date_unit=self.date_unit,
+            max_n_ticks=max_n_ticks, calendar=self.calendar
         )
         return locator.tick_values(num1, num2)
 
@@ -104,12 +99,12 @@ class Test_tick_values(unittest.TestCase):
 
     def test_minutely(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 1, 1.07), [1.0, 1.027778, 1.055556, 1.083333]
+            self.check(4, 1, 1.07), [1.0, 1.020833, 1.041667, 1.0625, 1.083333]
         )
 
     def test_hourly(self):
         np.testing.assert_array_almost_equal(
-            self.check(4, 2, 3), [2.0, 2.333333, 2.666667, 3.0]
+            self.check(4, 2, 3), [2.0, 2.25, 2.5, 2.75, 3.0]
         )
 
     def test_daily(self):
@@ -130,7 +125,6 @@ class Test_tick_values(unittest.TestCase):
 
 class Test_tick_values_yr0(unittest.TestCase):
     def setUp(self):
-        self.date_unit = "days since 0001-01-01 00:00"
         self.all_calendars = [
             "standard",
             "gregorian",
@@ -151,24 +145,27 @@ class Test_tick_values_yr0(unittest.TestCase):
 
     def check(self, max_n_ticks, num1, num2, calendar):
         locator = NetCDFTimeDateLocator(
-            max_n_ticks=max_n_ticks,
-            calendar=calendar,
-            date_unit=self.date_unit,
+            max_n_ticks=max_n_ticks, calendar=calendar
         )
         return locator.tick_values(num1, num2)
 
     def test_yearly_yr0_remove(self):
         for calendar in self.all_calendars:
             # convert values to dates, check that none of them has year 0
-            ticks = self.check(5, 0, 100 * 365, calendar)
+            ticks = self.check(5, -2001 * 365, -1901 * 365, calendar)
             year_ticks = [
-                cftime.num2date(t, self.date_unit, calendar=calendar).year
+                cftime.num2date(t, _TIME_UNITS, calendar=calendar).year
                 for t in ticks
             ]
             if calendar in self.yr0_remove_calendars:
                 self.assertNotIn(0, year_ticks)
             else:
                 self.assertIn(0, year_ticks)
+
+
+def test_NetCDFTimeDateLocator_date_unit_warning():
+    with pytest.warns(DeprecationWarning, match="date_unit"):
+        NetCDFTimeDateLocator(5, "360_day", "days since 2000-01-01")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🚀 Pull Request

This implements the proposal outlined in https://github.com/SciTools/nc-time-axis/issues/41#issuecomment-898895834.

### Description

The following example now works.  Here I am setting a single tick on the x-axis and labeling it with a date format of `"%Y-%m"` using the newly added `CFTimeFormatter`:

```python
import random

import cftime
import matplotlib.pyplot as plt
import nc_time_axis

dt = [cftime.DatetimeNoLeap(2017, 2, day, calendar="noleap") for day in range(1, 28)]
temperatures = [round(random.uniform(0, 12), 3) for _ in range(len(dt))]

fig, ax = plt.subplots(1, 1)
ax.plot(dt, temperatures)
ax.set_xticks([cftime.DatetimeNoLeap(2017, 2, 10)])
ax.xaxis.set_major_formatter(nc_time_axis.CFTimeFormatter("%Y-%m", "noleap"))
```

![example-xticks](https://user-images.githubusercontent.com/6628425/129477744-c90067ff-04e7-4912-a33d-7aecfe71a80d.png)

The `NetCDFTimeDateFormatter` has been renamed to `AutoCFTimeFormatter`.  For backwards compatibility, using the name `NetCDFTimeDateFormatter` will still work, but will raise a `FutureWarning`.
