### PR TITLE
Deprecate `CalendarDateTime`

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -24,6 +24,12 @@ class CalendarDateTime:
     """
 
     def __init__(self, datetime, calendar):
+        warnings.warn(
+            "CalendarDateTime is obsolete and will be deprecated in nc_time_axis "
+            "version 1.5.  Please consider switching to plotting instances or "
+            "subclasses of cftime.datetime directly.",
+            DeprecationWarning,
+        )
         self.datetime = datetime
         self.calendar = calendar
 

--- a/nc_time_axis/tests/integration/test_plot.py
+++ b/nc_time_axis/tests/integration/test_plot.py
@@ -1,6 +1,7 @@
 """Integration test for plotting data with non-gregorian calendar."""
 
 import unittest
+import warnings
 
 import matplotlib
 
@@ -24,6 +25,7 @@ class Test(unittest.TestCase):
         # in an odd state, so we make sure it's been disposed of.
         plt.close("all")
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_360_day_calendar_CalendarDateTime(self):
         calendar = "360_day"
         datetimes = [
@@ -62,6 +64,7 @@ class Test(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "defined"):
             plt.plot(datetimes)
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_fill_between(self):
         calendar = "360_day"
         dt = [
@@ -84,16 +87,19 @@ def teardown_function(function):
     plt.close()
 
 
-TICKS = {
-    "List[cftime.datetime]": [cftime.Datetime360Day(1986, 2, 1)],
-    "List[CalendarDateTime]": [
-        nc_time_axis.CalendarDateTime(
-            cftime.Datetime360Day(1986, 2, 1), "360_day"
-        )
-    ],
-}
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    TICKS = {
+        "List[cftime.datetime]": [cftime.Datetime360Day(1986, 2, 1)],
+        "List[CalendarDateTime]": [
+            nc_time_axis.CalendarDateTime(
+                cftime.Datetime360Day(1986, 2, 1), "360_day"
+            )
+        ],
+    }
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize("axis", ["x", "y"])
 @pytest.mark.parametrize("ticks", TICKS.values(), ids=list(TICKS.keys()))
 def test_set_ticks(axis, ticks):

--- a/nc_time_axis/tests/unit/test_CalendarDateTime.py
+++ b/nc_time_axis/tests/unit/test_CalendarDateTime.py
@@ -3,10 +3,12 @@
 import unittest
 
 import cftime
+import pytest
 
 from nc_time_axis import CalendarDateTime
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class Test___eq__(unittest.TestCase):
     def setUp(self):
         self.cdt = CalendarDateTime(
@@ -32,6 +34,7 @@ class Test___eq__(unittest.TestCase):
         self.assertFalse(self.cdt == "not a CalendarDateTime")
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class Test__ne__(unittest.TestCase):
     def setUp(self):
         self.cdt = CalendarDateTime(
@@ -55,6 +58,11 @@ class Test__ne__(unittest.TestCase):
 
     def test_diff_type(self):
         self.assertTrue(self.cdt != "not a CalendarDateTime")
+
+
+def test_CalendarDateTime_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        CalendarDateTime(cftime.datetime(2000, 1, 1), "gregorian")
 
 
 if __name__ == "__main__":

--- a/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -4,10 +4,12 @@ import unittest
 
 import cftime
 import numpy as np
+import pytest
 
 from nc_time_axis import CalendarDateTime, NetCDFTimeConverter
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class Test_axisinfo(unittest.TestCase):
     def test_axis_default_limits(self):
         cal = "360_day"
@@ -24,6 +26,7 @@ class Test_axisinfo(unittest.TestCase):
 
 
 class Test_default_units(unittest.TestCase):
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_360_day_calendar_point_CalendarDateTime(self):
         calendar = "360_day"
         unit = "days since 2000-01-01"
@@ -31,6 +34,7 @@ class Test_default_units(unittest.TestCase):
         result = NetCDFTimeConverter().default_units(val, None)
         self.assertEqual(result, (calendar, unit, CalendarDateTime))
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_360_day_calendar_list_CalendarDateTime(self):
         calendar = "360_day"
         unit = "days since 2000-01-01"
@@ -38,6 +42,7 @@ class Test_default_units(unittest.TestCase):
         result = NetCDFTimeConverter().default_units(val, None)
         self.assertEqual(result, (calendar, unit, CalendarDateTime))
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_360_day_calendar_nd_CalendarDateTime(self):
         # Test the case where the input is an nd-array.
         calendar = "360_day"
@@ -105,6 +110,7 @@ class Test_default_units(unittest.TestCase):
         result = NetCDFTimeConverter().default_units(val, None)
         self.assertEqual(result, (calendar, unit, cftime.datetime))
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_nonequal_calendars(self):
         # Test that different supplied calendars causes an error.
         calendar_1 = "360_day"
@@ -146,6 +152,7 @@ class Test_convert(unittest.TestCase):
         result = NetCDFTimeConverter().convert(val, None, None)
         np.testing.assert_array_equal(result, val)
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_cftime_CalendarDateTime(self):
         val = CalendarDateTime(cftime.datetime(2014, 8, 12), "365_day")
         result = NetCDFTimeConverter().convert(val, None, None)
@@ -195,6 +202,7 @@ class Test_convert(unittest.TestCase):
         assert result == expected
         assert len(result) == 1
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_cftime_np_array_CalendarDateTime(self):
         val = np.array(
             [CalendarDateTime(cftime.datetime(2012, 6, 4), "360_day")],
@@ -215,6 +223,7 @@ class Test_convert(unittest.TestCase):
         result = NetCDFTimeConverter().convert(val, None, None)
         self.assertEqual(result, np.array([4473.0]))
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_non_cftime_datetime(self):
         val = CalendarDateTime(4, "360_day")
         msg = (


### PR DESCRIPTION
## 🚀 Pull Request

Closes #81

This adds a `DeprecationWarning` to the `CalendarDateTime` constructor, which will allow us to remove it in nc-time-axis version 1.5.  These warnings are ignored when running our test suite to reduce noise.