### PR TITLE
Address deprecation of matplotlib's `is_numlike` method

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -16,6 +16,14 @@ New features
 
 Bug fixes
 ~~~~~~~~~
+* As of matplotlib version 3.5, unit converters no longer need to support
+  passing numeric or iterables of numeric values to their ``convert`` method.
+  Accordingly, the :py:meth:`matplotlib.units.ConversionInterface.is_numlike`
+  method has been deprecated.  For backwards compatibility with older versions
+  of matplotlib, we have vendored this function for the time being, but will
+  remove it once the minimum version of matplotlib supported by nc-time-axis is
+  at least 3.5 (:issue:`97`, :pull:`106`).  By `Spencer Clark
+  <https://github.com/spencerkclark>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -2,6 +2,7 @@
 Support for cftime axis in matplotlib.
 
 """
+from numbers import Number
 import warnings
 
 import cftime
@@ -10,6 +11,7 @@ import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.units as munits
 import numpy as np
+from numpy import ma
 
 from ._version import version as __version__  # noqa: F401
 
@@ -429,8 +431,11 @@ class NetCDFTimeConverter(mdates.DateConverter):
             value = value.reshape(-1)
             first_value = value[0]
         else:
-            # Don't do anything with numeric types.
-            if munits.ConversionInterface.is_numlike(value):
+            # Don't do anything with numeric types.  This check can be removed once
+            # the minimum version of matplotlib supported is at least 3.5, when
+            # convert is no longer required to support numeric or iterables of numeric
+            # types.  See GitHub issue 97 for more details.
+            if is_numlike(value):
                 return value
             # Not an array but a list of non-numerical types (thus assuming datetime types)
             elif isinstance(value, (list, tuple)):
@@ -468,6 +473,26 @@ class NetCDFTimeConverter(mdates.DateConverter):
             result = result.reshape(shape)
 
         return result
+
+
+def is_numlike(x):
+    """
+    The Matplotlib datalim, autoscaling, locators etc work with scalars
+    which are the units converted to floats given the current unit.  The
+    converter may be passed these floats, or arrays of them, even when
+    units are set.
+
+    Vendored for matplotlib.  This function will not be needed once the
+    minimum version of matplotlib supported by nc-time-axis is at least
+    3.5.  See GitHub issue 97 for more details.
+    """
+    if np.iterable(x):
+        for thisx in x:
+            if thisx is ma.masked:
+                continue
+            return isinstance(thisx, Number)
+    else:
+        return isinstance(x, Number)
 
 
 # Automatically register NetCDFTimeConverter with matplotlib.unit's converter

--- a/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
+++ b/nc_time_axis/tests/unit/test_NetCDFTimeConverter.py
@@ -143,11 +143,15 @@ class Test_convert(unittest.TestCase):
         self.assertEqual(result.shape, shape)
 
     def test_numeric(self):
+        # This test can be removed once the minimum version of matplotlib supported
+        # is at least 3.5.  See GitHub issue 97 for more details.
         val = 4
         result = NetCDFTimeConverter().convert(val, None, None)
         np.testing.assert_array_equal(result, val)
 
     def test_numeric_iterable(self):
+        # This test can be removed once the minimum version of matplotlib supported
+        # is at least 3.5.  See GitHub issue 97 for more details.
         val = [12, 18]
         result = NetCDFTimeConverter().convert(val, None, None)
         np.testing.assert_array_equal(result, val)


### PR DESCRIPTION
## 🚀 Pull Request

### Description

Closes #97.

Matplotlib has deprecated the `is_numlike` method.  In versions of matplotlib 3.5 or later, is no longer needed; however in prior versions it may still be required.  For backwards compatibility, we vendor the `is_numlike` method, which is short and self-contained, and will plan to remove it once the minimum version of matplotlib supported by nc-time-axis is at least 3.5.

