### PR TITLE
Use the `-k explicit` option when creating lockfiles in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,7 +89,7 @@ linux_task:
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${NCTA_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
     populate_script:
-      - conda-lock --mamba --platform linux-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
+      - conda-lock --lockfile conda-linux-64.lock --mamba --platform linux-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
       - mamba create --name py${PY_VER} --quiet --file conda-linux-64.lock
       - cp conda-linux-64.lock ${HOME}/mambaforge/envs/py${PY_VER}
   test_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,7 +89,7 @@ linux_task:
       - echo "$(date +%Y).$(expr $(date +%U) / ${CACHE_PERIOD}):${NCTA_CACHE_BUILD}"
       - cat ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
     populate_script:
-      - conda-lock --lockfile conda-linux-64.lock --mamba --platform linux-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
+      - conda-lock -k explicit --mamba --platform linux-64 --file ${CIRRUS_WORKING_DIR}/requirements/py$(echo ${PY_VER} | tr -d ".").yml
       - mamba create --name py${PY_VER} --quiet --file conda-linux-64.lock
       - cp conda-linux-64.lock ${HOME}/mambaforge/envs/py${PY_VER}
   test_script:


### PR DESCRIPTION
## 🚀 Pull Request

### Description

From @rcomer: the latest version of `conda-lock` creates lockfiles by default that cannot be used to generate environments with conda/mamba.  Using the `-k explicit` option restores the old behavior.  

See also: SciTools/iris#4644.
