### PR TITLE
No longer subclass `DateConverter` in `NetCDFTimeConverter`

### DIFF
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -454,7 +454,7 @@ class NetCDFTimeDateLocator(mticker.Locator):
         return cftime.date2num(ticks, self.date_unit, calendar=self.calendar)
 
 
-class NetCDFTimeConverter(mdates.DateConverter):
+class NetCDFTimeConverter(munits.ConversionInterface):
     """
     Converter for :py:class:`cftime.datetime` data.
 


### PR DESCRIPTION
## 🚀 Pull Request

This is a proof of concept to show that we can no longer subclass `mpl.dates.DateConverter` in `NetCDFTimeConverter` without any ill effects.  I think it is unlikely that anyone downstream is depending on this relatively low-level detail of nc-time-axis, so it feels reasonably safe to change without a deprecation cycle, but I would be open to opinions of folks who feel otherwise.

xref: https://github.com/matplotlib/matplotlib/issues/24951, https://github.com/matplotlib/matplotlib/pull/25662

cc: @ksunden
