### PR TITLE
Bump python versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -55,11 +55,11 @@ linux_task:
   auto_cancellation: true
   matrix:
     env:
-      PY_VER: "3.7"
-    env:
-      PY_VER: "3.8"
-    env:
       PY_VER: "3.9"
+    env:
+      PY_VER: "3.10"
+    env:
+      PY_VER: "3.11"
       COVERAGE: "codecov"
   name: "${CIRRUS_OS}: py${PY_VER}"
   container:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,9 @@
 version: 2
 
 build:
-    image: latest
+    os: ubuntu-20.04
+    tools:
+        python: mambaforge-4.10
 
 conda:
     environment: requirements/docs.yml

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ Minimum requirements
 * `cftime <https://unidata.github.io/cftime>`_ >= 1.5
 * `matplotlib <https://matplotlib.org/stable>`_
 * `numpy <https://numpy.org/doc/stable>`_
-* `python <https://docs.python.org/3>`_ >= 3.7
+* `python <https://docs.python.org/3>`_ >= 3.9
 
 Installation methods
 --------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 79
-target-version = ['py37', 'py38', 'py39']
+target-version = ['py39', 'py310', 'py311']
 include = '\.pyi?$'
 exclude = '''
 

--- a/requirements/docs.yml
+++ b/requirements/docs.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python 3.9
+  - python 3.11
 
 # setup dependencies
   - setuptools

--- a/requirements/ncta.yml
+++ b/requirements/ncta.yml
@@ -1,1 +1,1 @@
-py39.yml
+py311.yml

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python 3.8
+  - python 3.10
 
 # setup dependencies
   - setuptools

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python 3.7
+  - python 3.11
 
 # setup dependencies
   - setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,9 +9,9 @@ classifiers =
     Operating System :: POSIX :: Linux
     Operating System :: Unix
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
 description = Provides support for a cftime axis in matplotlib
 download_url = https://github.com/SciTools/nc-time-axis
@@ -39,7 +39,7 @@ install_requires =
     numpy
 packages = find:
 python_requires =
-    >=3.7
+    >=3.9
 zip_safe = False
 
 [options.extras_require]


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->
This PR increases the supported python versions to 3.9-3.11.  Support for v3.8 was due to end last week according to NEP29 recommendations.
https://numpy.org/neps/nep-0029-deprecation_policy.html

The tests pass for me locally under python 3.11.  The doc build failed under both 3.9 and 3.11, so let's see what readthedocs does...