### PR TITLE
bump download/upload artifact gha version

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           ls -l ${{ github.workspace }}/dist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pypi-artifacts
           path: ${{ github.workspace }}/dist
@@ -83,7 +83,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pypi-artifacts
           path: ${{ github.workspace }}/dist
@@ -102,7 +102,7 @@ jobs:
     name: "show artifacts"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pypi-artifacts
           path: ${{ github.workspace }}/dist
@@ -119,7 +119,7 @@ jobs:
     # upload to Test PyPI for every commit on main branch
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pypi-artifacts
           path: ${{ github.workspace }}/dist
@@ -140,7 +140,7 @@ jobs:
     # upload to PyPI for every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pypi-artifacts
           path: ${{ github.workspace }}/dist


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request replaces #186 and #187.

Migrating to the next version (`@3` -> `@4`) requires to be done consistently within a single pull-request for both of the `upload-artifact` and `download-artifact` GHAs.