### PR TITLE
nep29 drop numpy 1.22

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -15,6 +15,8 @@ Requirements
   By `Ruth Comer`_.
 * ``nc-time-axis`` now requires ``numpy >= 1.21`` according to `NEP29`_ (:pull:`129`).
   By `Bill Little`_.
+* ``nc-time-axis`` now requires ``numpy >= 1.23`` according to `NEP29`_ (:pull:`194`).
+  By `Bill Little`_.
 
 New Features
 ~~~~~~~~~~~~

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -13,7 +13,7 @@ dependencies:
 # core dependencies
   - cftime >=1.5
   - matplotlib-base
-  - numpy >=1.21
+  - numpy >=1.23
 
 # test dependencies
   - codecov

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -13,7 +13,7 @@ dependencies:
 # core dependencies
   - cftime >=1.5
   - matplotlib-base
-  - numpy >=1.21
+  - numpy >=1.23
 
 # test dependencies
   - codecov

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -13,7 +13,7 @@ dependencies:
 # core dependencies
   - cftime >=1.5
   - matplotlib-base
-  - numpy >=1.21
+  - numpy >=1.23
 
 # test dependencies
   - codecov

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -1,3 +1,3 @@
 cftime>=1.5
 matplotlib
-numpy>=1.21
+numpy>=1.23


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request enforces `nep29` and drops `numpy 1.22`, as scheduled.

See [NEP29 Drop Schedule](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule).