### PR TITLE
QA: Remove `warn_unreachable=true` from mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,11 +66,11 @@ disable_error_code = [
     "misc",
     "no-untyped-call",
     "no-untyped-def",
-    "unreachable",
+    "unreachable",  # TODO: Uncomment `warn_unreachable` below when fixed
 ]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = true
-warn_unreachable = true
+# warn_unreachable = true  # TODO: Enable once all unreachable code is fixed
 
 [tool.numpydoc_validation]
 checks = [
@@ -136,6 +136,7 @@ ignore = [
 
     # TODO: exceptions that still need investigating are below.
     # Might be fixable, or might become permanent (above):
+    "MY103", # Must have warn_unreachable enabled in mypy
     "PY007", # Supports an easy task runner (nox or tox)
     "PP309", # Filter warnings specified
     "PC170", # Uses PyGrep hooks (only needed if rST present)


### PR DESCRIPTION
## 🚀 Pull Request
### Description
Small update to turn comment out the following:

```
[mypy] warn_unreachable=true
```
as that check is listed in the `disable_error_code` list for mypy.

This also requires the `MY103` check adding to the `ignore` list in `repo-review`.

This was supposed to go into PR #293 , but it got merged before I could update.