### PR TITLE
Mambaforge to Miniforge3

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -57,9 +57,9 @@ jobs:
       - name: "mambaforge setup (python ${{ matrix.python-version }})"
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
-          channels: conda-forge,defaults
+          channels: conda-forge
           channel-priority: true
           auto-update-conda: true
           environment-file: "requirements/locks/py${{ matrix.python-version }}-linux-64.lock"


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

A recent release of `Miniforge` has broke this CI the fix requires renaming `Mambaforge` to `Miniforge`

Propagating this fix over from python-stratify
SciTools/python-stratify#302