### PR TITLE
Fixed Ruff A001 warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ import datetime
 project = "nc-time-axis"
 year = datetime.datetime.today().year
 author = f"{project} contributors"
-copyright = f"2016-{year}, {author}"
+copyright = f"2016-{year}, {author}"  # noqa: A001
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,6 @@ ignore = [
                # `convert` method
 
     # Flake8-builtins
-    "A001",  # builtin-variable-shadowing
     "A002",  # undocumented-public-method
 
     # Flake8-annotations


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Fixes Ruff linter warning A001 (builtin variable shadowing) with a `noqa`
Ref: #297 
