### PR TITLE
Fix Ruff A002 linter warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,6 @@ ignore = [
 
     # Flake8-builtins
     "A001",  # builtin-variable-shadowing
-    "A002",  # undocumented-public-method
 
     # Flake8-annotations
     "ANN001",  # missing-type-function-argument

--- a/src/nc_time_axis/__init__.py
+++ b/src/nc_time_axis/__init__.py
@@ -247,7 +247,7 @@ class CFTimeFormatter(mticker.Formatter):
         calendar strings.
     """
 
-    def __init__(self, format, calendar):
+    def __init__(self, format, calendar):  #  noqa: A002
         self.format = format
         self.calendar = calendar
 

--- a/src/nc_time_axis/tests/unit/test_CFTimeFormatter.py
+++ b/src/nc_time_axis/tests/unit/test_CFTimeFormatter.py
@@ -15,7 +15,7 @@ FORMATS = {
 
 
 @pytest.mark.parametrize(("format", "expected"), FORMATS.items())
-def test_CFTimeFormatter(format, expected):
+def test_CFTimeFormatter(format, expected):  # noqa: A002
     days = 3661 / 86400
     calendar = "360_day"
     formatter = CFTimeFormatter(format, calendar)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Ref: #297 
Fix Ruff A002 linter warnings (variable shadows builtin) with `noqa` directives. 