### PR TITLE
pep639: setuptools license and license-files fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@
 [build-system]
 # Defined by PEP 518
 requires = [
-  "setuptools>=61",
-  "setuptools_scm[toml]>=7",
+  "setuptools>=77.0.3",
+  "setuptools_scm[toml]>=8",
 ]
 # Defined by PEP 517
 build-backend = "setuptools.build_meta"
@@ -17,7 +17,6 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
@@ -40,7 +39,8 @@ keywords = [
   "cftime",
   "matplotlib",
 ]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 name = "nc-time-axis"
 requires-python = ">=3.11"
 
@@ -277,7 +277,6 @@ known-first-party = ["nc_time_axis"]
 convention = "numpy"
 
 [tool.setuptools]
-license-files = ["LICENSE"]
 zip-safe = false
 
 [tool.setuptools.dynamic]

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -8,8 +8,8 @@ dependencies:
   - python 3.11
 
 # setup dependencies
-  - setuptools >=61
-  - setuptools-scm >=7
+  - setuptools >=77.0.3
+  - setuptools-scm >=8
 
 # core dependencies
   - cftime >=1.5

--- a/requirements/py312.yml
+++ b/requirements/py312.yml
@@ -8,8 +8,8 @@ dependencies:
   - python 3.12
 
 # setup dependencies
-  - setuptools >=61
-  - setuptools-scm >=7
+  - setuptools >=77.0.3
+  - setuptools-scm >=8
 
 # core dependencies
   - cftime >=1.5

--- a/requirements/py313.yml
+++ b/requirements/py313.yml
@@ -8,8 +8,8 @@ dependencies:
   - python 3.13
 
 # setup dependencies
-  - setuptools >=61
-  - setuptools-scm >=7
+  - setuptools >=77.0.3
+  - setuptools-scm >=8
 
 # core dependencies
   - cftime >=1.5


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request complies with [PEP639](https://peps.python.org/pep-0639/) for `setuptools`, also see [license and license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).

Additionally avoids the following `setuptools` deprecation warning:
```
!!
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:
          License :: OSI Approved :: BSD License
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
!!
```